### PR TITLE
Separate TypeScript definitions from implementation logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,7 @@ Shebangs must appear **before** the header comment if present.
 | Private fields           | `#field` or `_field`                   | `#singleton`, `_cache`               |
 | Hook/event names         | PascalCase                             | `SettingsReady`, `ConfigUpdated`     |
 | Environment vars         | `OMH_*` prefix in SCREAMING_SNAKE_CASE | `OMH_DEBUG_MODE`, `OMH_MAX_TOKENS`   |
+| Type files               | `*-types.ts` (separate from logic)     | `logger-types.ts`, `config-types.ts` |
 
 **Module Lifecycle**:
 
@@ -283,10 +284,11 @@ npm run dev
 
 1. **Plan**: Document in `specs/00X-feature-name/tasks.md` if part of planned work
 2. **Write code**: Follow style guide, add file headers, comprehensive JSDoc
-3. **Write tests**: Unit tests for logic, integration tests for FoundryVTT interaction
-4. **Verify**: Run `npm test` (80%+ coverage), `npm run lint`, `npm run build` (no errors)
-5. **Document**: Update folder README if adding files or changing features; inline comments for complex logic
-6. **Commit**: Use conventional format (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`)
+3. **Extract types**: Declare all interfaces and types in a separate `module-types.ts` file; import into implementation
+4. **Write tests**: Unit tests for logic, integration tests for FoundryVTT interaction
+5. **Verify**: Run `npm test` (80%+ coverage), `npm run lint`, `npm run build` (no errors)
+6. **Document**: Update folder README if adding files or changing features; inline comments for complex logic
+7. **Commit**: Use conventional format (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`)
 
 ## Key Imports (Module Aliases)
 
@@ -354,6 +356,7 @@ Before submitting a pull request:
 - [ ] All files have `@file`, `@description`, `@path` headers
 - [ ] All functions/classes have JSDoc with `@param`, `@returns`, `@throws`
 - [ ] Naming follows conventions (PascalCase, camelCase, SCREAMING_SNAKE_CASE)
+- [ ] Types declared in separate `*-types.ts` file (not mixed with implementation)
 - [ ] Tests added/updated; coverage ≥80%
 - [ ] No FoundryVTT monkey-patching; hooks-only integration
 - [ ] Error messages include `[OMH]` prefix

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -33,6 +33,7 @@ The module MUST maintain clear separation of concerns with a view toward reuse a
   configs
 - Composition over inheritance preferred where technically feasible
 - Each module component MUST have explicitly defined responsibility and dependencies
+- Type definitions MUST be declared in separate `*-types.ts` files to avoid cluttering implementation logic
 - Code MUST follow established FoundryVTT coding standards and best practices
 - Error and log messages MUST be prepended by a configurable prefix for easy filtering and identification
 - Imports MUST use aliasing where available to ensure portability and clarity

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -187,7 +187,9 @@ Every directory MUST contain a `README.md` explaining its purpose. The README is
 
 ---
 
-## Naming Conventions
+### Naming Conventions
+
+- Type definitions MUST be placed in dedicated `*-types.ts` files separate from implementation files.
 
 ### Configuration Keys
 

--- a/docs/STYLE_GUIDE_QUICK_REFERENCE.md
+++ b/docs/STYLE_GUIDE_QUICK_REFERENCE.md
@@ -28,17 +28,18 @@
 
 ## Naming Conventions
 
-| Type           | Convention                  | Example          |
-| -------------- | --------------------------- | ---------------- |
-| Class          | PascalCase                  | `ConfigManager`  |
-| Function       | camelCase                   | `loadConfig()`   |
-| Variable       | camelCase                   | `isReady`        |
-| Constant       | SCREAMING_SNAKE_CASE        | `MAX_RETRIES`    |
-| Env Variable   | PREFIX_SCREAMING_SNAKE_CASE | `VWF_DEBUG_MODE` |
-| Hook           | PascalCase                  | `SettingsReady`  |
-| File (JS)      | camelCase.mjs               | `config.mjs`     |
-| File (TS)      | camelCase.mts               | `config.ts`     |
-| Private member | `_name` or `#name`          | `_internal`      |
+| Type           | Convention                  | Example           |
+| -------------- | --------------------------- | ----------------- |
+| Class          | PascalCase                  | `ConfigManager`   |
+| Function       | camelCase                   | `loadConfig()`    |
+| Variable       | camelCase                   | `isReady`         |
+| Constant       | SCREAMING_SNAKE_CASE        | `MAX_RETRIES`     |
+| Env Variable   | PREFIX_SCREAMING_SNAKE_CASE | `VWF_DEBUG_MODE`  |
+| Hook           | PascalCase                  | `SettingsReady`   |
+| File (JS)      | camelCase.mjs               | `config.mjs`      |
+| File (TS)      | camelCase.mts               | `config.ts`       |
+| Type file      | `*-types.ts`                | `logger-types.ts` |
+| Private member | `_name` or `#name`          | `_internal`       |
 
 ---
 
@@ -207,6 +208,7 @@ import { Config } from './config.ts';
 - [ ] File has `@file`, `@description`, `@path` header
 - [ ] Functions/classes have JSDoc comments
 - [ ] Naming follows conventions
+- [ ] Types live in dedicated `*-types.ts` files
 - [ ] 2-space indentation
 - [ ] Errors include `[VWF]` prefix
 - [ ] No FoundryVTT monkey-patching (hooks only)

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -27,6 +27,7 @@ The singleton config is:
 ```
 src/config/
 ├── config.ts               # Config singleton class (main entry point)
+├── config-types.ts         # Type definitions for Config interface
 ├── README.md               # This file
 ├── helpers/
 │   ├── configHelpers.ts   # Helper functions for loading/parsing

--- a/src/config/config-types.ts
+++ b/src/config/config-types.ts
@@ -1,0 +1,23 @@
+/**
+ * @file config-types.ts
+ * @description Type definitions for the centralized configuration singleton
+ * @path src/config/config-types.ts
+ */
+
+/**
+ * Configuration interface
+ * @typedef {Object} Config
+ * @property {Record<string, unknown>} constants - Merged YAML constants from all constant files
+ * @property {unknown} settings - Settings definitions array
+ * @property {Record<string, unknown>} module - Module manifest from module.json
+ * @property {Record<string, string>} env - Environment variables matching prefix pattern
+ * @property {string} toString - Method to serialize config to string
+ */
+export interface Config {
+  constants: Record<string, unknown>;
+  settings: unknown[];
+  module: Record<string, unknown>;
+  env: Record<string, string>;
+  prefix: string;
+  toString(): string;
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -35,8 +35,8 @@ import type { Config } from './config-types.ts';
  * console.log(config.module.id); // "vision-with-fade"
  * console.log(config.constants.errors.separator); // " || "
  *
- * // Config is immutable
- * config.module.id = 'modified'; // Throws or fails silently
+ * // ConfigService instance is immutable
+ * config.module.id = 'modified'; // Fails silently with warning logged
  */
 class ConfigService {
   /** @type {Record<string, unknown>} Merged YAML constants */
@@ -61,8 +61,8 @@ class ConfigService {
   private static instance: ConfigService | null = null;
 
   /**
-   * Create and initialize a new Config instance
-   * This is called once on first import; subsequent imports return cached instance
+   * Create and initialize a new ConfigService instance.
+   * This is called once on first import; subsequent imports return cached instance.
    *
    * @constructor
    * @throws {Error} If any configuration file fails to load or parse
@@ -124,7 +124,7 @@ class ConfigService {
       );
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      const errorMessage = `[OMH] CONFIG INITIALIZATION FAILED: ${errorMsg}`;
+      const errorMessage = `[${this.#prefix}] CONFIG INITIALIZATION FAILED: ${errorMsg}`;
       console.error(errorMessage);
       throw new Error(errorMessage);
     }
@@ -393,10 +393,10 @@ class ConfigService {
 let cachedProxy: Config | null = null;
 
 /**
- * Wrap config in a Proxy to ignore direct mutation attempts at top-level
- * Proxy is created once and cached to optimize repeated access
- * @param {ConfigService} instance Config singleton instance
- * @returns {Config} Proxy instance presented to consumers
+ * Wrap ConfigService instance in a Proxy to ignore direct mutation attempts at top-level.
+ * Proxy is created once and cached to optimize repeated access.
+ * @param {ConfigService} instance ConfigService singleton instance to wrap
+ * @returns {Config} Proxy typed as Config interface presented to consumers
  */
 function createConfigProxy(instance: ConfigService): Config {
   // Return cached proxy if already created

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,16 +13,7 @@ import {
   loadEnvironmentVariables,
 } from './helpers/configHelpers.ts';
 import { cloneDeep } from 'lodash';
-
-/**
- * Configuration interface
- * @typedef {Object} Config
- * @property {Record<string, unknown>} constants - Merged YAML constants from all constant files
- * @property {unknown} settings - Settings definitions array
- * @property {Record<string, unknown>} module - Module manifest from module.json
- * @property {Record<string, string>} env - Environment variables matching prefix pattern
- * @property {string} toString - Method to serialize config to string
- */
+import type { Config } from './config-types.ts';
 
 /**
  * Centralized Configuration Service (Singleton)
@@ -36,7 +27,7 @@ import { cloneDeep } from 'lodash';
  * The singleton is frozen after initialization to prevent runtime modifications.
  * Fail-fast error handling ensures configuration issues are caught immediately.
  *
- * @class Config
+ * @class ConfigService
  * @example
  * import { config } from './config.ts';
  *
@@ -47,7 +38,7 @@ import { cloneDeep } from 'lodash';
  * // Config is immutable
  * config.module.id = 'modified'; // Throws or fails silently
  */
-class Config {
+class ConfigService {
   /** @type {Record<string, unknown>} Merged YAML constants */
   #yamlConstants: Record<string, unknown> = {};
 
@@ -66,8 +57,8 @@ class Config {
   /** @type {string} Configuration prefix from module shortName */
   #prefix: string = 'OMH';
 
-  /** @type {Config | null} Singleton instance */
-  private static instance: Config | null = null;
+  /** @type {ConfigService | null} Singleton instance */
+  private static instance: ConfigService | null = null;
 
   /**
    * Create and initialize a new Config instance
@@ -180,18 +171,18 @@ class Config {
    * Get the singleton Config instance
    * Creates and caches the instance on first call; returns cached instance thereafter
    *
-   * @returns {Config} The singleton Config instance
+   * @returns {ConfigService} The singleton Config instance
    * @throws {Error} If initialization fails
    * @example
-   * const config = Config.getInstance();
+   * const config = ConfigService.getInstance();
    * // Or use direct import:
    * import { config } from './config.ts';
    */
-  static getInstance(): Config {
-    if (!Config.instance) {
-      Config.instance = new Config();
+  static getInstance(): ConfigService {
+    if (!ConfigService.instance) {
+      ConfigService.instance = new ConfigService();
     }
-    return Config.instance;
+    return ConfigService.instance;
   }
 
   /**
@@ -404,10 +395,10 @@ let cachedProxy: Config | null = null;
 /**
  * Wrap config in a Proxy to ignore direct mutation attempts at top-level
  * Proxy is created once and cached to optimize repeated access
- * @param {Config} instance Config singleton instance
+ * @param {ConfigService} instance Config singleton instance
  * @returns {Config} Proxy instance presented to consumers
  */
-function createConfigProxy(instance: Config): Config {
+function createConfigProxy(instance: ConfigService): Config {
   // Return cached proxy if already created
   if (cachedProxy) {
     return cachedProxy;
@@ -449,10 +440,10 @@ function createConfigProxy(instance: Config): Config {
 /**
  * Raw Config singleton instance
  * Created eagerly to ensure initialization before proxy wrapping
- * @type {Config}
+ * @type {ConfigService}
  * @private
  */
-const _rawConfigInstance: Config = Config.getInstance();
+const _rawConfigInstance: ConfigService = ConfigService.getInstance();
 
 /**
  * Singleton config instance exported for application-wide use
@@ -470,6 +461,7 @@ const _rawConfigInstance: Config = Config.getInstance();
 const proxiedConfig: Config = createConfigProxy(_rawConfigInstance);
 
 export { proxiedConfig as config };
+export { ConfigService };
 
 export type { Config };
 export default proxiedConfig;

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -33,6 +33,13 @@ This design provides:
 - Easy addition of new static utilities
 - Protection from internal refactoring
 
+### Files
+
+- `static.ts` - Centralized entrypoint for all static utilities
+- `static-types.ts` - Type definitions for static utilities (re-exported from submodules)
+- `static/devModeParser.ts` - Development/debug mode status evaluation
+- `static/devModeParser-types.ts` - Type definitions for DevModeParser
+
 ## Changelog
 
 ### 0.1.0 (2025-10-20)

--- a/src/utils/static-types.ts
+++ b/src/utils/static-types.ts
@@ -1,0 +1,14 @@
+/**
+ * @file static-types.ts
+ * @description Type definitions for static utility classes and aggregators
+ * @path src/utils/static-types.ts
+ */
+
+export type {
+  ConfigSource,
+  ModeStatus,
+  ConfigResult,
+  HierarchyKey,
+  ModeEvaluationOptions,
+  ConfigSingleton,
+} from './static/devModeParser-types.ts';

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -14,7 +14,7 @@ export type {
   HierarchyKey,
   ModeEvaluationOptions,
   ConfigSingleton,
-} from './static/devModeParser.ts';
+} from './static-types.ts';
 
 /**
  * StaticUtils provides a centralized interface to all static utility functionality.

--- a/src/utils/static/README.md
+++ b/src/utils/static/README.md
@@ -4,6 +4,11 @@
 
 This folder contains static utility classes that provide common functionality for data validation, object manipulation, configuration parsing, and other utility operations. All utilities are designed to be stateless and can be used throughout the application without instantiation (except where noted).
 
+## Files
+
+- `devModeParser.ts` - Development/debug mode status evaluation
+- `devModeParser-types.ts` - Type definitions for DevModeParser (separate from implementation)
+
 ## Public API
 
 **Import the StaticUtils class** from the centralized entrypoint (`src/utils/static.ts`):

--- a/src/utils/static/devModeParser-types.ts
+++ b/src/utils/static/devModeParser-types.ts
@@ -1,0 +1,43 @@
+/**
+ * @file devModeParser-types.ts
+ * @description Type definitions for development and debug mode status evaluation
+ * @path src/utils/static/devModeParser-types.ts
+ */
+
+/**
+ * Configuration source value that can be evaluated as a mode status.
+ */
+export type ConfigSource = string | boolean | undefined | null;
+
+/**
+ * Boolean representation of a mode's activation status.
+ */
+export type ModeStatus = boolean;
+
+/**
+ * Result object containing both development and debug mode status.
+ */
+export type ConfigResult = {
+  devMode: ModeStatus;
+  debugMode: ModeStatus;
+};
+
+/**
+ * Key identifying a configuration source within the evaluation hierarchy.
+ */
+export type HierarchyKey = 'env' | 'module' | 'setting';
+
+/**
+ * Options for customizing mode evaluation behavior.
+ */
+export type ModeEvaluationOptions = {
+  hierarchy?: readonly HierarchyKey[];
+};
+
+/**
+ * Configuration singleton interface for reading mode values from multiple sources.
+ */
+export interface ConfigSingleton {
+  get(key: string, source: 'env' | 'module' | 'setting'): ConfigSource;
+  prefix?: string;
+}

--- a/src/utils/static/devModeParser.ts
+++ b/src/utils/static/devModeParser.ts
@@ -5,25 +5,14 @@
  * @path src/utils/static/devModeParser.ts
  */
 
-export type ConfigSource = string | boolean | undefined | null;
-
-export type ModeStatus = boolean;
-
-export type ConfigResult = {
-  devMode: ModeStatus;
-  debugMode: ModeStatus;
-};
-
-export type HierarchyKey = 'env' | 'module' | 'setting';
-
-export type ModeEvaluationOptions = {
-  hierarchy?: readonly HierarchyKey[];
-};
-
-export interface ConfigSingleton {
-  get(key: string, source: 'env' | 'module' | 'setting'): ConfigSource;
-  prefix?: string;
-}
+import type {
+  ConfigSource,
+  ModeStatus,
+  ConfigResult,
+  HierarchyKey,
+  ModeEvaluationOptions,
+  ConfigSingleton,
+} from './devModeParser-types.ts';
 
 const LOG_PREFIX = '[DevModeParser]';
 
@@ -287,3 +276,12 @@ class DevModeParser {
 }
 
 export default DevModeParser;
+
+export type {
+  ConfigSource,
+  ModeStatus,
+  ConfigResult,
+  HierarchyKey,
+  ModeEvaluationOptions,
+  ConfigSingleton,
+} from './devModeParser-types.ts';


### PR DESCRIPTION
This pull request introduces a standardized approach for separating type definitions from implementation code across the codebase. The changes enforce the use of dedicated `*-types.ts` files for all TypeScript type and interface declarations, update documentation and style guides to reflect this convention, and refactor the configuration and utility modules to comply. This improves code clarity, maintainability, and adherence to modern best practices.

**Documentation and Style Guide Updates:**

* Updated `.github/copilot-instructions.md`, `docs/STYLE_GUIDE.md`, and `docs/STYLE_GUIDE_QUICK_REFERENCE.md` to require all type definitions to be placed in separate `*-types.ts` files and added checklist items to enforce this during PR review. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R65) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L286-R291) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R359) [[4]](diffhunk://#diff-d2adc1eebb3bcd5bf6298ad22b60cccfee0e21315462af82bbdd40aa4b073f57L190-R192) [[5]](diffhunk://#diff-b3973c1066a29913095dcc18116e69a01ee2af75db7f10eae3f80d39824abda5R41) [[6]](diffhunk://#diff-b3973c1066a29913095dcc18116e69a01ee2af75db7f10eae3f80d39824abda5R211) [[7]](diffhunk://#diff-68da6d0a6818ee87101f0e2220e30cfa038e7deeb68c2a35344636db6d6da2bcR36)
* Added examples and directory structure documentation for type files in `src/config/README.md` and `src/utils/README.md`, and updated quick references for file naming conventions. [[1]](diffhunk://#diff-975304eaa5d56d33e909acb2ce0aaae2dc7a4408aa34b3ee9338b65a76a42d7fR30) [[2]](diffhunk://#diff-47d56e08f68bc687a331ca260f0ad3211d935a2aa8767f89e33d31ec0c7d14ddR36-R42) [[3]](diffhunk://#diff-3ca1bb2f812c5babc196d253b24b331e871c859bf5f3f0fbf81c54b45c0829baR7-R11) [[4]](diffhunk://#diff-b3973c1066a29913095dcc18116e69a01ee2af75db7f10eae3f80d39824abda5L32-R32)

**Configuration Module Refactor:**

* Created a new `src/config/config-types.ts` file for the `Config` interface and updated all references in `src/config/config.ts` to import types from this file. Renamed the main configuration class to `ConfigService` for clarity and updated related documentation/comments. [[1]](diffhunk://#diff-ae6d70147c084fc931ca96a201a2454a635b4f35774f90f6c8aff97de0576cddR1-R23) [[2]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L16-R16) [[3]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L39-R41) [[4]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L69-R65) [[5]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L136-R127) [[6]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L183-R185) [[7]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L405-R401) [[8]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L452-R446) [[9]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755R464)

**Static Utilities Refactor:**

* Introduced `src/utils/static-types.ts` to centralize type definitions for static utilities, and moved all type exports in `src/utils/static.ts` to import from this new file. [[1]](diffhunk://#diff-50f09d64234509d01206368bccc30d2cb15feadd186ea3de4a6c7e532a5d8478R1-R14) [[2]](diffhunk://#diff-12e9d4b8c35ae25ced79492ce9d72c84899888c13f7d7224a7a552e115d6fb0cL17-R17)
* Created `src/utils/static/devModeParser-types.ts` for type definitions used by `devModeParser`, updated all related imports/exports, and removed inline type declarations from `devModeParser.ts`. [[1]](diffhunk://#diff-12bcbf2af19b7a47e3aa53708f8368bfc035077a1d64e06ed2251cf6e68b7deaR1-R43) [[2]](diffhunk://#diff-71c09fe3600e1e817dfed046d5444c915e329d8d5ff9dfa8293249533fec5812L8-R15) [[3]](diffhunk://#diff-71c09fe3600e1e817dfed046d5444c915e329d8d5ff9dfa8293249533fec5812R279-R287)

These changes collectively ensure a clear separation between type definitions and implementation logic, improving code organization and future maintainability.This pull request introduces a project-wide convention to extract all TypeScript type definitions into dedicated `*-types.ts` files, separating them from implementation logic. It updates the documentation and coding standards, refactors existing code to follow the new pattern, and adds new type definition files for configuration and utility modules.

**Project-wide adoption of separate type definition files:**

- Updated the style guide and development process documentation to require all interfaces and types to be declared in separate `*-types.ts` files, with examples and checklist updates for PRs. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R65) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L286-R291) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R359) [[4]](diffhunk://#diff-68da6d0a6818ee87101f0e2220e30cfa038e7deeb68c2a35344636db6d6da2bcR36)

**Refactoring configuration types:**

- Extracted the `Config` interface from `src/config/config.ts` into a new `src/config/config-types.ts` file, and updated all relevant imports and type usages. [[1]](diffhunk://#diff-ae6d70147c084fc931ca96a201a2454a635b4f35774f90f6c8aff97de0576cddR1-R23) [[2]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L16-R16)
- Renamed the configuration singleton class from `Config` to `ConfigService` in `src/config/config.ts` and updated all references for clarity. [[1]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L39-R30) [[2]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L50-R41) [[3]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L69-R61) [[4]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L183-R185) [[5]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L407-R401) [[6]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755L452-R446) [[7]](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755R464)

**Refactoring static utility types:**

- Moved all type definitions used by static utility classes from `src/utils/static/devModeParser.ts` into a new `src/utils/static/devModeParser-types.ts` file, and updated imports accordingly. [[1]](diffhunk://#diff-12bcbf2af19b7a47e3aa53708f8368bfc035077a1d64e06ed2251cf6e68b7deaR1-R43) [[2]](diffhunk://#diff-71c09fe3600e1e817dfed046d5444c915e329d8d5ff9dfa8293249533fec5812L8-R15) [[3]](diffhunk://#diff-71c09fe3600e1e817dfed046d5444c915e329d8d5ff9dfa8293249533fec5812R279-R287)
- Added a central type re-export file `src/utils/static-types.ts` and updated `src/utils/static.ts` to import types from this new file. [[1]](diffhunk://#diff-50f09d64234509d01206368bccc30d2cb15feadd186ea3de4a6c7e532a5d8478R1-R14) [[2]](diffhunk://#diff-12e9d4b8c35ae25ced79492ce9d72c84899888c13f7d7224a7a552e115d6fb0cL17-R17)- Add src/utils/static-types.ts to re-export types from ./static/devModeParser-types.ts
- Update src/utils/static.ts to import/re-export types from ./static-types.ts instead of from the implementation
- Decouple type definitions from implementation to centralize type exports and reduce coupling